### PR TITLE
未ログイン時に記録ページとグループページにアクセスすると404エラーになる問題を解消

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,9 +9,10 @@ Rails.application.routes.draw do
     # ログイン済み → / (Home)
     authenticated :user do
       root to: "home#index", as: :authenticated_root
-      resources :groups, only: [ :index, :new, :create ]
-      resources :exercise_logs, only: [ :index, :new, :create ]
     end
+
+    resources :groups,        only: [:index, :new, :create]
+    resources :exercise_logs, only: [:index, :new, :create]
 
   root "top#index"
 


### PR DESCRIPTION
下記内容の修正をしています
・config/routes.rbの記録ページとグループページへのルートをauthenticated :user doの外に記載し、未ログイン時に記録ページとグループページにアクセスすると、ログイン画面に遷移するように修正しました。