### PR TITLE
グループ招待リンク機能の実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,4 +16,12 @@ class ApplicationController < ActionController::Base
           .first
       end
   end
+
+  def after_sign_in_path_for(resource)
+    if (token = session.delete(:pending_invite_token)).present?
+      invite_path(token: token)
+    else
+      super
+    end
+  end
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -9,6 +9,10 @@ class GroupsController < ApplicationController
     @group = Group.new
   end
 
+  def show
+    @group = current_user.groups.find(params[:id])
+  end
+
   def create
   @group = Group.new(group_params.merge(owner_id: current_user.id))
   if @group.save

--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -1,0 +1,33 @@
+class InvitesController < ApplicationController
+  before_action :set_group
+  before_action :authenticate_user!, only: :accept
+
+  MAX_MEMBERS = 5
+
+  def show
+  end
+
+  def accept
+    if @group.users.exists?(current_user.id)
+      redirect_to @group, notice: "すでにメンバーです" and return
+    end
+
+    if @group.users.count >= MAX_MEMBERS
+      redirect_to invite_path(token: params[:token]), alert: "満員です" and return
+    end
+
+    @group.group_memberships.create!(user: current_user, joined_at: Time.current)
+
+    redirect_to @group, notice: "グループに参加しました"
+
+  rescue ActiveRecord::RecordNotUnique
+    redirect_to @group, notice: "すでにメンバーです"
+  end
+
+  private
+
+  def set_group
+    @group = Group.find_by(invite_token: params[:token])
+    redirect_to root_path, alert: "招待リンクが無効です" unless @group
+  end
+end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,7 +1,12 @@
 class Group < ApplicationRecord
-  belongs_to :owner, class_name: "User", optional: true
+  belongs_to :owner, class_name: "User", optional: false
   has_many :group_memberships, dependent: :destroy
   has_many :users, through: :group_memberships
 
   validates :name, presence: true, length: { maximum: 50 }
+
+  before_create :ensure_invite_token
+  def ensure_invite_token
+    self.invite_token ||= SecureRandom.urlsafe_base64(24)
+  end
 end

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -3,11 +3,38 @@
 </section>
 
 <% @groups.each do |group| %>
-  <h3><%= group.name %></h3>
-  <%= button_to "グループを抜ける",
-      group_membership_path(group),
-      method: :delete,
-      form: { data: { turbo: false } },
-      data: { turbo_confirm: "本当に退会しますか？" },
-      class: "btn btn-outline" %>
+  <div class="group-card">
+    <h3><%= link_to group.name, group_path(group) %></h3>
+    <p>現在 <%= group.users.count %> 人</p>
+
+    <% if group.owner_id == current_user.id && group.invite_token.present? %>
+      <div class="invite-block mt-2">
+        <p class="text-sm">
+          招待リンク：
+          <span class="font-mono break-all"><%= link_to invite_path(token: group.invite_token),invite_path(token: group.invite_token),class: "font-mono break-all underline" %></span>
+        </p>
+        <button
+          type="button"
+          data-copy="<%= invite_path(token: group.invite_token) %>"
+          onclick="(async (btn)=>{try{
+            await navigator.clipboard.writeText(btn.dataset.copy);
+            const old = btn.textContent; btn.textContent='コピーしました';
+            setTimeout(()=>btn.textContent=old||'コピー',1500);
+          }catch(e){
+            prompt('コピーできない場合は手動でコピーしてください', btn.dataset.copy);
+          }})(this)">
+          コピー
+        </button>
+      </div>
+    <% end %>
+
+    <%# unless group.owner_id == current_user.id %>  <!-- オーナーには退会ボタンを見せない。開発用にコメントアウト -->
+      <%= button_to "グループを抜ける",
+          group_membership_path(group),
+          method: :delete,
+          form: { data: { turbo: false } },
+          data: { turbo_confirm: "本当に退会しますか？" },
+          class: "btn btn-outline" %>
+    <%# end %>
+  </div>
 <% end %>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -1,0 +1,7 @@
+<h1><%= @group.name %></h1>
+<p>メンバー数：<%= @group.users.count %></p>
+
+<% if @group.owner_id == current_user.id && @group.invite_token.present? %>
+  <h2>招待リンク</h2>
+  <p><%= invite_path(token: @group.invite_token) %></p>
+<% end %>

--- a/app/views/invites/show.html.erb
+++ b/app/views/invites/show.html.erb
@@ -1,0 +1,6 @@
+<h1><%= @group.name %> に参加しますか？</h1>
+
+<%= button_to "このグループに参加する",
+    accept_invite_path(token: params[:token]),
+    method: :post,
+    form: { data: { turbo: false } } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
       root to: "home#index", as: :authenticated_root
     end
 
-    resources :groups, only: [ :index, :new, :create ] do
+    resources :groups, only: [ :index, :new, :create, :show ] do
       resource :membership, only: [ :destroy ]
     end
 
@@ -21,6 +21,9 @@ Rails.application.routes.draw do
   # 開発用（直接アクセスしたい時用）
   get :top,  to: "top#index"
   get :home, to: "home#index"
+
+  get  "invite/:token", to: "invites#show",   as: :invite
+  post "invite/:token", to: "invites#accept", as: :accept_invite
 
   get "/privacy", to: "static_pages#privacy", as: :privacy
   get "/terms",   to: "static_pages#terms",   as: :terms

--- a/db/migrate/20251001055533_add_invite_token_to_groups.rb
+++ b/db/migrate/20251001055533_add_invite_token_to_groups.rb
@@ -1,0 +1,6 @@
+class AddInviteTokenToGroups < ActiveRecord::Migration[8.0]
+  def change
+    add_column :groups, :invite_token, :string
+    add_index :groups, :invite_token, unique: true
+  end
+end

--- a/db/migrate/20251002073931_add_unique_index_to_group_memberships.rb
+++ b/db/migrate/20251002073931_add_unique_index_to_group_memberships.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToGroupMemberships < ActiveRecord::Migration[8.0]
+  def change
+    add_index :group_memberships, [ :group_id, :user_id ], unique: true
+  end
+end

--- a/script/backfill_invite_tokens.rb
+++ b/script/backfill_invite_tokens.rb
@@ -1,0 +1,5 @@
+Group.where(invite_token: [ nil, "" ]).find_each do |g|
+  g.update_columns(
+    invite_token: SecureRandom.base58(22),
+  )
+end


### PR DESCRIPTION
### 概要
***
- グループに 招待リンクを発行・共有し、リンクを踏んだユーザーが参加できる機能を追加しました。参加者は招待リンクから直接グループに参加可能になります。

### 変更点
***
- Group モデル
  - invite_token を自動生成する処理を追加
- Invites コントローラー
  - show アクションで招待ページを表示
  - accept アクションで参加処理を追加
- Groups コントローラー
  - グループ一覧にオーナー専用の招待リンク表示を追加
  - グループ詳細でメンバー数や招待リンクを表示
- ビュー
  - グループリーダーのみ招待リンクとコピー機能を表示
  - 招待ページに「このグループに参加する」ボタンを設置
- マイグレーション
  - groups に invite_token カラムを追加し、ユニーク制約を付ける
  - group_memberships にユニーク制約を追加し、同一ユーザーの重複参加を防止
