### PR TITLE
GoogleアナリティクスGA4、PV計測を実装

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,6 +1,32 @@
 <!DOCTYPE html>
 <html lang="ja" data-theme="light">
 <head>
+<%# Google Analytics 後でターボに統一する%>
+  <% if Rails.env.production? && ENV["GA_MEASUREMENT_ID"].present? %>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=<%= ENV["GA_MEASUREMENT_ID"] %>"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){ dataLayer.push(arguments); }
+      gtag('js', new Date());
+      gtag('config', '<%= ENV["GA_MEASUREMENT_ID"] %>', { send_page_view: false });
+
+      function sendPV(){
+        if (!window.gtag) return;
+        var path = location.pathname + location.search;
+        if (window.__ga_last_path === path) return;
+        window.__ga_last_path = path;
+        gtag('config', '<%= ENV["GA_MEASUREMENT_ID"] %>', {
+          page_location: location.href,
+          page_path: path,
+          page_title: document.title
+        });
+      }
+
+      document.addEventListener('DOMContentLoaded', sendPV);
+      document.addEventListener('turbo:load', sendPV);
+    </script>
+  <% end %>
+
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <meta name="format-detection" content="telephone=no">
   <title><%= content_for?(:title) ? yield(:title) : "ヘルスノ陣" %></title>


### PR DESCRIPTION
### 概要
***
-  Googleアナリティクス（GA4）を導入し、PVの計測を可能にしました。
- 将来的にTurboを使用する場合でも正しく計測できるようにしています。
### 変更内容
***
- ` views/layouts`にGA4タグを追加しています。