### PR TITLE
グループ加入時/未加入時のホーム画面uiの調整

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,5 +1,5 @@
 @import "tailwindcss";
-@plugin "daisyui";
+@plugin "daisyui"{themes: light --default, dark --prefersdark, luxury;}
 
 @theme {
   --font-serif: "Kaisei Decol", ui-serif, serif;
@@ -12,4 +12,16 @@
   --color-muted: var(--color-slate-600);
 
   --spacing-45: 11.25rem;
+}
+
+@layer base {
+  [data-theme="goldbtn"] {
+    --color-primary: #D4AF37;
+    --color-primary-content: #2b1b00;
+  }
+
+  [data-theme="pinkbtn"] {
+    --color-primary: #E75480;
+    --color-primary-content: #4b1f2c;
+  }
 }

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,8 +1,14 @@
 <% if @active_group.present? %>
   <!-- HomeB,グループ加入後 -->
+
   <div class="text-center">
     <div class="mt-10 sm:mt-14">
-      <%= image_tag castle_image_path_for(@progress.total_points),alt: "城の画像",class: "mx-auto",width: 200, height: 200 %>
+      <h2 class="text-center text-xl md:text-2xl font-bold tracking-tight">
+        <span class="block mx-auto truncate max-w-[80vw] md:max-w-[600px]">
+          <%= @active_group.name %>の城
+        </span>
+      </h2>
+      <%= image_tag castle_image_path_for(@progress.total_points),alt: "城の画像",class: "mx-auto mt-2",width: 200, height: 200 %>
 
       <% pb = progress_bar(@progress) %>
 
@@ -19,11 +25,8 @@
           <span><%= pb.end_label %></span>
         </div>
       </div>
-
-      <p class="mt-2 text-base">グループ名：<%= @active_group.name %></p>
     </div>
-
-    <%= link_to "運動を記録する", new_exercise_log_path, class: "btn btn-primary" %>
+    <%= link_to "運動を記録する",new_exercise_log_path,class: "btn btn-primary",data: { theme: "pinkbtn" } %>
   </div>
 <% else %>
   <!-- HomeA, グループ未加入の場合 -->
@@ -33,8 +36,7 @@
       <div class="card-body items-center text-center space-y-6">
         <h1 class="card-title text-lg md:text-xl">まずはグループ参加・作成しよう</h1>
 
-        <%= link_to "グループを作成", new_group_path,
-              class: "btn btn-lg w-full rounded-full bg-blue-900 hover:bg-blue-800 text-white border-none" %>
+        <%= link_to "グループを作成",new_group_path,class: "btn btn-lg w-full rounded-full btn-primary",data: { theme: "goldbtn" } %>
 
         <p class="text-sm text-base-content/60">
           ※グループに参加する場合は、リーダーから送られた<strong>招待リンク</strong>から参加してね！


### PR DESCRIPTION
### 概要
***
- グループ加入時と未加入時のホーム画面のuiを調整しました。
### 変更内容
***
- グループ未加入時ホーム画面
  - グループ作成ボタンを goldbtn テーマで金色にしました。
- グループ加入時ホーム画面
  - 運動を記録するボタンを pinkbtn テーマで濃いピンクに変更しました。
  - 城画像上部に、`グループ名`の城と表示されるようにしました。
